### PR TITLE
Update to latest DragonFly BSD release

### DIFF
--- a/dragonflybsd/Makefile
+++ b/dragonflybsd/Makefile
@@ -1,3 +1,5 @@
+ISO=dfly-x86_64-5.2.1_REL.iso
+
 .PHONY: install-boxes install-box-virtualbox
 
 all: install-boxes
@@ -7,8 +9,14 @@ install-boxes: install-box-virtualbox
 install-box-virtualbox: dragonflybsd-virtualbox.box
 	vagrant box add -f --name mcandre/dragonflybsd --provider virtualbox dragonflybsd-virtualbox.box
 
-dragonflybsd-virtualbox.box: dragonflybsd.json http/p *.sh Vagrantfile
-	PACKER_LOG=1 packer build -force -only virtualbox-iso dragonflybsd.json
+$(ISO).bz2:
+	wget https://mirror-master.dragonflybsd.org/iso-images/$(ISO).bz2
+
+$(ISO): $(ISO).bz2
+	bunzip2 $(ISO).bz2
+
+dragonflybsd-virtualbox.box: dragonflybsd.json $(ISO) http/p *.sh Vagrantfile
+	PACKER_LOG=1 packer build -force -only virtualbox-iso -var 'iso=$(ISO)' dragonflybsd.json
 
 clean: clean-boxes clean-vagrant clean-artifacts clean-isos
 

--- a/dragonflybsd/dragonflybsd.json
+++ b/dragonflybsd/dragonflybsd.json
@@ -1,10 +1,13 @@
 {
+  "variables": {
+    "iso": ""
+  },
   "builders": [
     {
       "type": "virtualbox-iso",
       "guest_os_type": "FreeBSD_64",
       "vm_name": "dragonflybsd",
-      "iso_url": "http://mirror-master.dragonflybsd.org/iso-images/dfly-x86_64-5.2.0_REL.iso",
+      "iso_url": "{{user `iso`}}",
       "iso_checksum_type": "md5",
       "iso_checksum_url": "http://avalon.dragonflybsd.org/iso-images/md5.txt",
       "ssh_username": "vagrant",


### PR DESCRIPTION
In addition to updating to a newer version of DragonFly, the latest as
of this commit, 5.2.1, this changes out the design to use variables in
most places for the ISO name and version so that to update everything
going forward all that needs to be changed is one line in the
Makefile. The Makefile and packer build file were adjusted
accordingly.