### PR TITLE
Switch to Debian 9.7

### DIFF
--- a/debian/debian-amd64.json
+++ b/debian/debian-amd64.json
@@ -1,9 +1,9 @@
 {
     "variables": {
         "vm_name": "debian-amd64",
-        "iso_url": "https://cdimage.debian.org/cdimage/release/9.4.0/amd64/iso-cd/debian-9.4.0-amd64-netinst.iso",
+        "iso_url": "https://cdimage.debian.org/cdimage/release/9.7.0/amd64/iso-cd/debian-9.7.0-amd64-netinst.iso",
         "iso_checksum_type": "sha512",
-        "iso_checksum_url": "https://cdimage.debian.org/cdimage/release/9.4.0/amd64/iso-cd/SHA512SUMS",
+        "iso_checksum_url": "https://cdimage.debian.org/cdimage/release/9.7.0/amd64/iso-cd/SHA512SUMS",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
         "ssh_wait_timeout": "6h",


### PR DESCRIPTION
Hello,

Debian 9.7 [1] was released a few days ago.

Thanks.

[1] https://www.debian.org/News/2019/20190123