### PR TITLE
Fix script syntax error: unexpected end of file.

### DIFF
--- a/dragonflybsd/ssh-configure-vagrant-key.dragonflybsd.sh
+++ b/dragonflybsd/ssh-configure-vagrant-key.dragonflybsd.sh
@@ -4,4 +4,4 @@ pkg update &&
     fetch -o /home/vagrant/.ssh/authorized_keys https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub &&
     chown -R vagrant:vagrant /home/vagrant/.ssh &&
     chmod 0700 /home/vagrant/.ssh &&
-    chmod 0600 /home/vagrant/.ssh/authorized_keys &&
+    chmod 0600 /home/vagrant/.ssh/authorized_keys


### PR DESCRIPTION
A change to a dragonflybsd shell script sometime last year seems to have broken the script. Just removing the double ampersand on the last line.